### PR TITLE
Update 2020_06_03_192100_add_columns_for_people_table.php

### DIFF
--- a/src/migrations/2020_06_03_192100_add_columns_for_people_table.php
+++ b/src/migrations/2020_06_03_192100_add_columns_for_people_table.php
@@ -11,8 +11,8 @@ class AddColumnsForPeopleTable extends Migration
         Schema::table('people', function (Blueprint $table) {
             $table->string('gid')->nullable();
             $table->string('givn')->nullable();
-            $table->string('surn', 255)->nullable();
-            $table->string('name', 255)->nullable()->change();
+            $table->string('surn', 191)->nullable();
+            $table->string('name', 191)->nullable()->change();
 
             $table->string('type')->nullable();
             $table->string('npfx')->nullable();


### PR DESCRIPTION
Default String length set to 191
you can refer to below link to find why I set it to 191

https://stackoverflow.com/questions/43832166/laravel-5-4-specified-key-was-too-long-why-the-number-191