### PR TITLE
parse error 

### DIFF
--- a/src/Utils/GedcomParser.php
+++ b/src/Utils/GedcomParser.php
@@ -36,7 +36,8 @@ class GedcomParser
     protected $conn = '';
 
     public function parse(
-      $conn,
+      /* $conn, */
+      $conn = "",
       string $filename,
       string $slug,
       bool $progressBar = NULL,


### PR DESCRIPTION
just given null value 
public function parse(  
       /* $conn, */
      $conn = "",
      string $filename,
      string $slug,
      bool $progressBar = NULL,
      $channel = ['name' => 'gedcom-progress1', 'eventName' => 'newMessage']
    )