### PR TITLE
parse error

### DIFF
--- a/src/Utils/GedcomParser.php
+++ b/src/Utils/GedcomParser.php
@@ -36,7 +36,8 @@ class GedcomParser
     protected $conn = '';
 
     public function parse(
-      $conn,
+      /* $conn, */
+      $conn = "",
       string $filename,
       string $slug,
       bool $progressBar = NULL,

--- a/src/Utils/GedcomParser.php
+++ b/src/Utils/GedcomParser.php
@@ -37,9 +37,9 @@ class GedcomParser
 
     public function parse(
       /* $conn, */
-      $conn = "",
       string $filename,
       string $slug,
+      $conn = "",
       bool $progressBar = NULL,
       $channel = ['name' => 'gedcom-progress1', 'eventName' => 'newMessage']
     )


### PR DESCRIPTION
if you didn't change README.md in GedcomParserFacade::parse(filename, true); other wise update README.md file like this GedcomParserFacade::parse("", filename, true) 